### PR TITLE
Add TypeORM MySQL + Kafka example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,24 @@
 # play
-བཀྲ་ཤིས་བདེ་ལེགས། ང་ནི་Dia Atef Ahmed ཡིན། ང་ནི་@EG ཡི་སློབ་མ་ཡིན། སློབ་མའི་ཨང་རྟགས་ @tanduc265ab ཡིན། ཧི།
-play1
+
+This is a simple example project demonstrating how to integrate
+[TypeORM](https://typeorm.io) with a MySQL database and a Kafka broker.
+
+## Getting Started
+
+1. Install dependencies (requires npm with internet access):
+   ```bash
+   npm install
+   ```
+2. Compile TypeScript sources:
+   ```bash
+   npm run build
+   ```
+3. Start the application:
+   ```bash
+   npm start
+   ```
+
+The app connects to MySQL using environment variables `DB_HOST`, `DB_PORT`,
+`DB_USER`, `DB_PASSWORD` and `DB_NAME`. It also connects to Kafka using the
+`KAFKA_BROKERS` variable. Defaults are provided for local development.
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "play",
+  "version": "1.0.0",
+  "description": "Sample project integrating TypeORM with MySQL and Kafka",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "ts-node src/index.ts",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "kafkajs": "^2.2.4",
+    "mysql": "^2.18.1",
+    "reflect-metadata": "^0.1.13",
+    "typeorm": "^0.3.20"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.1",
+    "typescript": "^5.2.2"
+  }
+}
+

--- a/src/data-source.ts
+++ b/src/data-source.ts
@@ -1,0 +1,25 @@
+import "reflect-metadata";
+import { DataSource } from "typeorm";
+import { User } from "./entity/User";
+
+export const AppDataSource = new DataSource({
+  type: "mysql",
+  host: process.env.DB_HOST || "localhost",
+  port: +(process.env.DB_PORT || 3306),
+  username: process.env.DB_USER || "root",
+  password: process.env.DB_PASSWORD || "password",
+  database: process.env.DB_NAME || "test",
+  entities: [User],
+  synchronize: true,
+  logging: false,
+});
+
+export const initializeDatabase = async () => {
+  try {
+    await AppDataSource.initialize();
+    console.log("Database connected");
+  } catch (err) {
+    console.error("Database connection failed", err);
+    throw err;
+  }
+};

--- a/src/entity/User.ts
+++ b/src/entity/User.ts
@@ -1,0 +1,10 @@
+import { Entity, PrimaryGeneratedColumn, Column } from "typeorm";
+
+@Entity()
+export class User {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  name: string;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,27 @@
+import { initializeDatabase } from "./data-source";
+import { connectKafka, consumer, producer } from "./kafka";
+import { User } from "./entity/User";
+import { AppDataSource } from "./data-source";
+
+const start = async () => {
+  await initializeDatabase();
+  await connectKafka();
+
+  consumer.run({
+    eachMessage: async ({ topic, partition, message }) => {
+      console.log(`received message: ${message.value?.toString()}`);
+    },
+  });
+
+  const userRepo = AppDataSource.getRepository(User);
+  const user = userRepo.create({ name: "Alice" });
+  await userRepo.save(user);
+  await producer.send({
+    topic: "users",
+    messages: [{ value: `User created: ${user.name}` }],
+  });
+};
+
+start().catch((err) => {
+  console.error(err);
+});

--- a/src/kafka.ts
+++ b/src/kafka.ts
@@ -1,0 +1,15 @@
+import { Kafka } from "kafkajs";
+
+const kafka = new Kafka({
+  clientId: "my-app",
+  brokers: (process.env.KAFKA_BROKERS || "localhost:9092").split(","),
+});
+
+export const producer = kafka.producer();
+export const consumer = kafka.consumer({ groupId: "test-group" });
+
+export const connectKafka = async () => {
+  await producer.connect();
+  await consumer.connect();
+  console.log("Kafka connected");
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "es2018",
+    "module": "commonjs",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add package.json for TypeORM, MySQL and Kafka support
- configure TypeScript compiler
- implement basic TypeORM datasource with MySQL
- implement Kafka utilities
- create example entity and app entry point
- document setup in README

## Testing
- `npm test` *(fails: no test specified)*
- `npm install` *(fails: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_b_6841844e14a08327b14fff7c6ea02650